### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-coupa/main.go
+++ b/cmd/baton-coupa/main.go
@@ -34,6 +34,7 @@ func getConnector(ctx context.Context, cc *cfg.Coupa, connectorOpts *cli.Connect
 		cc.CoupaClientId,
 		cc.CoupaClientSecret,
 		syncAccountGroups,
+		cc.BaseUrl,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,6 +7,7 @@ type Coupa struct {
 	CoupaClientId string `mapstructure:"coupa-client-id"`
 	CoupaClientSecret string `mapstructure:"coupa-client-secret"`
 	CoupaDomain string `mapstructure:"coupa-domain"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Coupa) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,10 @@ var (
 		field.WithRequired(true),
 		field.WithDescription("Your Coupa Domain, ex: acme.coupacloud.com"),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Coupa API URL (for testing)"),
+	)
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or
 	// required.
@@ -42,6 +46,7 @@ var (
 		ClientIdField,
 		ClientSecretField,
 		CoupaDomain,
+		BaseURLField,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Coupa API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Coupa API URL (for testing)"),
+		field.WithHidden(true),
 	)
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -18,6 +18,7 @@ import (
 const (
 	ActionEnableUser  = "enable_user"
 	ActionDisableUser = "disable_user"
+	successKey        = "success"
 )
 
 var enableUserAction = &v2.BatonActionSchema{
@@ -35,7 +36,7 @@ var enableUserAction = &v2.BatonActionSchema{
 	},
 	ReturnTypes: []*config.Field{
 		{
-			Name:        "success",
+			Name:        successKey,
 			DisplayName: "Success",
 			Description: "Indicates whether the user was successfully enabled",
 			Field:       &config.Field_BoolField{},
@@ -61,7 +62,7 @@ var disableUserAction = &v2.BatonActionSchema{
 	},
 	ReturnTypes: []*config.Field{
 		{
-			Name:        "success",
+			Name:        successKey,
 			DisplayName: "Success",
 			Description: "Indicates whether the user was successfully disabled",
 			Field:       &config.Field_BoolField{},
@@ -127,7 +128,7 @@ func extractAndValidateUserId(args *structpb.Struct) (string, int, error) {
 func createActionResponse(success bool) *structpb.Struct {
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": structpb.NewBoolValue(success),
+			successKey: structpb.NewBoolValue(success),
 		},
 	}
 }

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -39,6 +39,7 @@ func New(
 	clientId string,
 	clientSecret string,
 	syncAccountGroups bool,
+	baseURLOverride string,
 ) (*Client, error) {
 	httpClient, err := uhttp.NewClient(
 		ctx,
@@ -51,14 +52,21 @@ func New(
 		return nil, err
 	}
 
-	normalizedUrl, err := config.NormalizeCoupaURL(instanceUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	baseUrl, err := url.Parse(normalizedUrl)
-	if err != nil {
-		return nil, err
+	var baseUrl *url.URL
+	if baseURLOverride != "" {
+		baseUrl, err = url.Parse(baseURLOverride)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		normalizedUrl, err := config.NormalizeCoupaURL(instanceUrl)
+		if err != nil {
+			return nil, err
+		}
+		baseUrl, err = url.Parse(normalizedUrl)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	coupaClient := &Client{

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -53,12 +53,13 @@ func New(
 	}
 
 	var baseUrl *url.URL
-	if baseURLOverride != "" {
+	switch {
+	case baseURLOverride != "":
 		baseUrl, err = url.Parse(baseURLOverride)
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	default:
 		normalizedUrl, err := config.NormalizeCoupaURL(instanceUrl)
 		if err != nil {
 			return nil, err

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -65,6 +65,7 @@ func New(
 	clientId string,
 	clientSecret string,
 	syncAccountGroups bool,
+	baseURL string,
 ) (*Connector, error) {
 	coupaClient, err := client.New(
 		ctx,
@@ -72,6 +73,7 @@ func New(
 		clientId,
 		clientSecret,
 		syncAccountGroups,
+		baseURL,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-coupa/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/client/client.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-coupa --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.