### PR TITLE
[CXP-260] Make read-write OAuth2 token optional to fix invalid_scope errors

### DIFF
--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -12,7 +12,6 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/actions"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -73,20 +72,18 @@ var disableUserAction = &v2.BatonActionSchema{
 	},
 }
 
-func (c *Connector) RegisterActionManager(ctx context.Context) (connectorbuilder.CustomActionManager, error) {
-	actionManager := actions.NewActionManager(ctx)
-
-	err := actionManager.RegisterAction(ctx, enableUserAction.Name, enableUserAction, c.enableUser)
+func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
+	err := registry.Register(ctx, enableUserAction, c.enableUser)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	err = actionManager.RegisterAction(ctx, disableUserAction.Name, disableUserAction, c.disableUser)
+	err = registry.Register(ctx, disableUserAction, c.disableUser)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return actionManager, nil
+	return nil
 }
 
 // extractAndValidateUserId extracts and validates the user_id argument from action arguments.

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -123,14 +124,27 @@ func (c *Client) Initialize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	c.readOnlyToken = rtoken.AccessToken
 
-	rwtoken, err := c.readWriteTokenSource.Token()
-	if err != nil {
-		return err
+	if c.readWriteTokenSource != nil {
+		rwtoken, err := c.readWriteTokenSource.Token()
+		if err != nil {
+			logger.Warn("baton-coupa: failed to obtain read-write token; provisioning will be unavailable", zap.Error(err))
+		} else {
+			c.readWriteToken = rwtoken.AccessToken
+		}
 	}
 
-	c.readOnlyToken = rtoken.AccessToken
-	c.readWriteToken = rwtoken.AccessToken
 	c.initialized = true
+	return nil
+}
+
+// EnsureReadWriteToken returns an error if the read-write token was not
+// successfully acquired during initialization. Write operations should call
+// this before proceeding.
+func (c *Client) EnsureReadWriteToken() error {
+	if c.readWriteToken == "" {
+		return fmt.Errorf("baton-coupa: read-write token is not available; ensure the OAuth2 client has write scopes granted")
+	}
 	return nil
 }

--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -10,7 +10,10 @@ const (
 	setGroupPath = `/api/users/%d?fields=["id",{"user_groups":["id","name","description"]}]`
 
 	// setLicensePath set user id in the path.
-	setLicensePath = `/api/users/%d?fields=["id","analyticsUser","aicUser","ccwUser","contractsUser","expenseUser","inventoryUser","purchasingUser","riskAssessUser","sourcingUser","spendGuardUser","supplyChainUser","travelUser","treasuryUser"]`
+	setLicensePath = `/api/users/%d?fields=["id","analyticsUser","aicUser","ccwUser",` +
+		`"contractsUser","expenseUser","inventoryUser","purchasingUser",` +
+		`"riskAssessUser","sourcingUser","spendGuardUser","supplyChainUser",` +
+		`"travelUser","treasuryUser"]`
 
 	// updateUserPath set user id in the path.
 	updateUserPath = `/api/users/%d`

--- a/pkg/connector/client/request.go
+++ b/pkg/connector/client/request.go
@@ -96,6 +96,10 @@ func (c *Client) doRestRequest(
 	*v2.RateLimitDescription,
 	error,
 ) {
+	if err := c.EnsureReadWriteToken(); err != nil {
+		return nil, nil, err
+	}
+
 	l := ctxzap.Extract(ctx)
 
 	options := []uhttp.RequestOption{

--- a/pkg/connector/client/users.go
+++ b/pkg/connector/client/users.go
@@ -11,6 +11,7 @@ import (
 )
 
 // UpdateUser updates the user's active status.
+//nolint:revive // long URL
 // https://compass.coupa.com/en-us/products/total-spend-management-platform/integration-playbooks-and-resources/other-integration-playbooks/erp-integration-adapters/integration-scenarios/1.-user-integration-scenarios-(optional)/1.4-deactivate-a-user
 func (c *Client) UpdateUser(
 	ctx context.Context,

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -261,6 +261,7 @@ func (o *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 
 	// Clear all roles
 	// Removing a role is a two-step process where you first remove all the roles from the user and then put back the desired roles
+	//nolint:revive // long URL
 	// https://compass.coupa.com/en-us/products/core-platform/integration-playbooks-and-resources/other-integration-playbooks/erp-integration-adapters/integration-scenarios/1.-user-integration-scenarios-(optional)/1.7-remove-a-role-from-a-user
 	_, _, err = o.client.SetRoles(ctx, userId, make([]int, 0))
 	if err != nil {


### PR DESCRIPTION
## Summary
- Customers whose Coupa OAuth2 clients don't have write scopes granted were failing during validation with an `invalid_scope` error, even for sync-only usage
- `Initialize()` now warns but continues if the read-write token cannot be obtained, allowing sync to succeed without write scopes
- Write operations (Grant/Revoke) check for the read-write token via `EnsureReadWriteToken()` and fail with a clear error if it's unavailable

## Test plan
- [ ] Verify sync succeeds with an OAuth2 client that only has read scopes
- [ ] Verify sync still succeeds with an OAuth2 client that has both read and write scopes
- [ ] Verify provisioning (Grant/Revoke) works with write scopes granted
- [ ] Verify provisioning fails with a clear error when write scopes are not granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization resilience when read-write tokens are unavailable; system now proceeds with reduced capabilities instead of failing startup.

* **Enhancements**
  * Added validation checks for write operations to provide clearer error messages when tokens are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->