### PR TITLE
fix: do not request account groups scope when sync targets unspecified

### DIFF
--- a/cmd/baton-coupa/main.go
+++ b/cmd/baton-coupa/main.go
@@ -28,7 +28,7 @@ func main() {
 }
 
 func getConnector(ctx context.Context, cc *cfg.Coupa, connectorOpts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
-	syncAccountGroups := slices.Contains(connectorOpts.SyncResourceTypeIDs, connector.AccountGroupResourceTypeID) || len(connectorOpts.SyncResourceTypeIDs) == 0
+	syncAccountGroups := slices.Contains(connectorOpts.SyncResourceTypeIDs, connector.AccountGroupResourceTypeID)
 	cb, err := connector.New(
 		ctx,
 		cc.CoupaDomain,


### PR DESCRIPTION
## Summary

- In lambda deployments, c1 filters resource types via the SDK syncer running in the c1 process, so `connectorOpts.SyncResourceTypeIDs` is always empty inside the lambda binary. The previous `|| len(...) == 0` fallback in `cmd/baton-coupa/main.go` forced `syncAccountGroups=true` and appended `core.accounting.read` to every OAuth token request — even when the customer never opted into account group sync.
- Coupa rejects the token exchange with `invalid_scope` when the OAuth client lacks that scope, surfacing as `validate failed: oauth2: "invalid_scope"` and breaking sync before any work runs.
- Account groups are already gated behind `OptInRequired{}` (see `pkg/connector/resource_types.go`), so requiring an explicit `--sync-resource-types account_group,...` entry to request the accounting scope matches the existing opt-in contract.

## Test plan

- [x] `go build ./cmd/baton-coupa`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make lint`
- [ ] Verify in a tenant whose Coupa OAuth client lacks `core.accounting.read` that validation now succeeds with the default `resource_type_ids` (`group`, `license`, `role`, `user`).
- [ ] Verify a tenant that opts into `account_group` via `--sync-resource-types` still gets the accounting scope and syncs account groups successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)