### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -116,7 +116,7 @@ A user with **Admin** access in Coupa must perform this task.
   </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Coupa connector
 
@@ -173,7 +173,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your Coupa connector is now pulling access data into C1.
+**Done.** Your Coupa connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -294,7 +294,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your Coupa connector is now pulling access data into C1.
+**Done.** Your Coupa connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes depend on the connector — may include one or more of:

- Restore \`**Done.**\` closing phrase (replaces \`**That's it!**\`)
- Restore correct check icon color (\`#c937ae\`)
- Restore \`BATON_PROVISIONING: true\` flag in Kubernetes secrets block (with comment)

These corrections prevent the sync bot from reintroducing regressions on future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)