### PR TITLE
feat: add Content Groups (business_groups) as opt-in resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ baton resources
 - Roles
 - Licenses
 - Account Groups (opt-in; requires the `core.accounting.read` OAuth scope and must be selected in ConductorOne when configuring the connector)
+- Content Groups (opt-in; uses the `core.common.read` OAuth scope — already required by the base connector — and must be selected in ConductorOne when configuring the connector)
 
 # Actions
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ baton resources
 - Groups
 - Roles
 - Licenses
-- Account Groups (opt-in; requires the `core.accounting.read` OAuth scope and must be selected in ConductorOne when configuring the connector)
-- Content Groups (opt-in; uses the `core.common.read` OAuth scope — already required by the base connector — and must be selected in ConductorOne when configuring the connector)
+- Account Groups
+- Content Groups
 
 # Actions
 

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -10,9 +10,6 @@
             "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
           },
           {
-            "@type": "type.googleapis.com/c1.connector.v2.OptInRequired"
-          },
-          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {
@@ -44,8 +41,7 @@
             "permission": "core.user.write"
           }
         ]
-      },
-      "optInRequired": true
+      }
     },
     {
       "resourceType": {
@@ -54,9 +50,6 @@
         "annotations": [
           {
             "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
-          },
-          {
-            "@type": "type.googleapis.com/c1.connector.v2.OptInRequired"
           },
           {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
@@ -90,8 +83,7 @@
             "permission": "core.user.write"
           }
         ]
-      },
-      "optInRequired": true
+      }
     },
     {
       "resourceType": {

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -49,6 +49,52 @@
     },
     {
       "resourceType": {
+        "id": "content_group",
+        "displayName": "Content Group",
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.OptInRequired"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "core.common.read"
+              },
+              {
+                "permission": "core.user.read"
+              },
+              {
+                "permission": "core.user.write"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC",
+        "CAPABILITY_PROVISION"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "core.common.read"
+          },
+          {
+            "permission": "core.user.read"
+          },
+          {
+            "permission": "core.user.write"
+          }
+        ]
+      },
+      "optInRequired": true
+    },
+    {
+      "resourceType": {
         "id": "group",
         "displayName": "group",
         "traits": [

--- a/cmd/baton-coupa/main.go
+++ b/cmd/baton-coupa/main.go
@@ -22,18 +22,20 @@ func main() {
 		version,
 		cfg.Config,
 		getConnector,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{SyncAccountGroups: true}),
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{SyncAccountGroups: true, SyncContentGroups: true}),
 	)
 }
 
 func getConnector(ctx context.Context, cc *cfg.Coupa, connectorOpts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	syncAccountGroups := connectorOpts.WillSyncResourceType(connector.AccountGroupResourceTypeID)
+	syncContentGroups := connectorOpts.WillSyncResourceType(connector.ContentGroupResourceTypeID)
 	cb, err := connector.New(
 		ctx,
 		cc.CoupaDomain,
 		cc.CoupaClientId,
 		cc.CoupaClientSecret,
 		syncAccountGroups,
+		syncContentGroups,
 		cc.BaseUrl,
 	)
 	if err != nil {

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -16,11 +16,14 @@ sidebarTitle: "Coupa"
 | :--- | :--- | :--- |
 | Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Account Groups ¹ | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Content Groups ² | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Licenses | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 
 ¹ Account Groups sync is opt-in. To enable it, select **Account Groups** in the resource types to sync when configuring the connector in C1, and ensure the `core.accounting.read` OAuth scope is added to your Coupa OAuth client.
+
+² Content Groups sync is opt-in. To enable it, select **Content Groups** in the resource types to sync when configuring the connector in C1. No additional OAuth scopes are required beyond the standard configuration.
 
 ### Connector actions
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -15,15 +15,11 @@ sidebarTitle: "Coupa"
 | Resource | Sync | Provision |
 | :--- | :--- | :--- |
 | Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
-| Account Groups ¹ | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-| Content Groups ² | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Account Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Content Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Groups | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Licenses | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-
-¹ Account Groups sync is opt-in. To enable it, select **Account Groups** in the resource types to sync when configuring the connector in C1, and ensure the `core.accounting.read` OAuth scope is added to your Coupa OAuth client.
-
-² Content Groups sync is opt-in. To enable it, select **Content Groups** in the resource types to sync when configuring the connector in C1. No additional OAuth scopes are required beyond the standard configuration.
 
 ### Connector actions
 
@@ -71,6 +67,7 @@ A user with **Admin** access in Coupa must perform this task.
     - Select scopes:
 
   **You'll need these scopes to give C1 READ access (syncing access data):**
+    - core.accounting.read
     - core.business_entity.read
     - core.common.read
     - core.user_group.read
@@ -80,10 +77,8 @@ A user with **Admin** access in Coupa must perform this task.
     - openid
     - profile
 
-  **If you also want to sync Account Groups, add:**
-    - core.accounting.read
-
   **You'll need these scopes to give C1 READ/WRITE access (syncing access data and provisioning access):**
+    - core.accounting.read
     - core.business_entity.read
     - core.business_entity.write
     - core.common.read
@@ -96,9 +91,6 @@ A user with **Admin** access in Coupa must perform this task.
     - login
     - openid
     - profile
-
-  **If you also want to sync and provision Account Groups, add:**
-    - core.accounting.read
   </Step>
   <Step>
   At the bottom of the page click **Save**.
@@ -301,5 +293,3 @@ spec:
 
 </Tab>
 </Tabs>
-
-

--- a/pkg/connector/account_groups.go
+++ b/pkg/connector/account_groups.go
@@ -203,8 +203,8 @@ func (o *accountGroupBuilder) Revoke(ctx context.Context, g *v2.Grant) (annotati
 	return nil, nil
 }
 
-func (o *accountGroupBuilder) getUserAccountGroups(ctx context.Context, userId int) (*client.UserWithAccountGroups, error) {
-	var target client.UserAccountGroupsQueryResponse
+func (o *accountGroupBuilder) getUserAccountGroups(ctx context.Context, userId int) (*client.UserWithGroups, error) {
+	var target client.UserGroupsQueryResponse
 	response, _, err := o.client.Query(
 		ctx,
 		client.GetUserAccountGroupsByID(userId),

--- a/pkg/connector/client/auth.go
+++ b/pkg/connector/client/auth.go
@@ -13,6 +13,12 @@ const (
 	// Only requested when sync-account-groups is enabled, since existing
 	// OAuth clients may not have this scope configured.
 	ScopeAccountingRead = "core.accounting.read"
+
+	// ScopeCommonRead covers the business_groups (Content Groups) API endpoint.
+	// This scope is already included in ScopesReadOnly, so no conditional scope
+	// injection is required for content groups (unlike account groups which need
+	// the dedicated core.accounting.read scope).
+	ScopeCommonRead = "core.common.read"
 )
 
 var (

--- a/pkg/connector/client/auth.go
+++ b/pkg/connector/client/auth.go
@@ -13,12 +13,6 @@ const (
 	// Only requested when sync-account-groups is enabled, since existing
 	// OAuth clients may not have this scope configured.
 	ScopeAccountingRead = "core.accounting.read"
-
-	// ScopeCommonRead covers the business_groups (Content Groups) API endpoint.
-	// This scope is already included in ScopesReadOnly, so no conditional scope
-	// injection is required for content groups (unlike account groups which need
-	// the dedicated core.accounting.read scope).
-	ScopeCommonRead = "core.common.read"
 )
 
 var (

--- a/pkg/connector/client/content_groups.go
+++ b/pkg/connector/client/content_groups.go
@@ -39,7 +39,7 @@ func (c *Client) SetContentGroups(
 
 	var userResponse UserContentGroupsApiResponse
 
-	_, rateLimit, err := c.doRestRequest(
+	response, rateLimit, err := c.doRestRequest(
 		ctx,
 		http.MethodPut,
 		c.baseUrl.JoinPath(fmt.Sprintf(setContentGroupPath, userId)),
@@ -49,6 +49,7 @@ func (c *Client) SetContentGroups(
 	if err != nil {
 		return nil, rateLimit, err
 	}
+	defer response.Body.Close()
 
 	return &userResponse, rateLimit, nil
 }

--- a/pkg/connector/client/content_groups.go
+++ b/pkg/connector/client/content_groups.go
@@ -39,7 +39,7 @@ func (c *Client) SetContentGroups(
 
 	var userResponse UserContentGroupsApiResponse
 
-	response, rateLimit, err := c.doRestRequest(
+	_, rateLimit, err := c.doRestRequest(
 		ctx,
 		http.MethodPut,
 		c.baseUrl.JoinPath(fmt.Sprintf(setContentGroupPath, userId)),
@@ -49,7 +49,6 @@ func (c *Client) SetContentGroups(
 	if err != nil {
 		return nil, rateLimit, err
 	}
-	defer response.Body.Close()
 
 	return &userResponse, rateLimit, nil
 }

--- a/pkg/connector/client/content_groups.go
+++ b/pkg/connector/client/content_groups.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+// SetContentGroups sets the content groups (business_groups) for a user.
+// Content groups in Coupa are also known as business groups in the API.
+// https://compass.coupa.com/en-us/products/product-documentation/integration-technical-documentation/the-coupa-core-api/resources/reference-data-resources/content-groups-api-(business_groups)
+func (c *Client) SetContentGroups(
+	ctx context.Context,
+	userId int,
+	contentGroupIDs []int,
+) (
+	*UserContentGroupsApiResponse,
+	*v2.RateLimitDescription,
+	error,
+) {
+	err := c.Initialize(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	request := struct {
+		ContentGroups []ResourceId `json:"content-groups"`
+	}{}
+
+	if len(contentGroupIDs) == 0 {
+		request.ContentGroups = nil
+	} else {
+		for _, id := range contentGroupIDs {
+			request.ContentGroups = append(request.ContentGroups, ResourceId{Id: id})
+		}
+	}
+
+	var userResponse UserContentGroupsApiResponse
+
+	response, rateLimit, err := c.doRestRequest(
+		ctx,
+		http.MethodPut,
+		c.baseUrl.JoinPath(fmt.Sprintf(setContentGroupPath, userId)),
+		request,
+		&userResponse,
+	)
+	if err != nil {
+		return nil, rateLimit, err
+	}
+	defer response.Body.Close()
+
+	return &userResponse, rateLimit, nil
+}

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -123,15 +123,18 @@ type AccountGroupsQueryResponse struct {
 	AccountGroups []*AccountGroup `json:"accountGroups"`
 }
 
-type UserWithAccountGroups struct {
+type UserWithGroups struct {
 	Id            int `json:"id"`
 	AccountGroups []struct {
 		Id int `json:"id"`
 	} `json:"accountGroups"`
+	ContentGroups []struct {
+		Id int `json:"id"`
+	} `json:"contentGroups"`
 }
 
-type UserAccountGroupsQueryResponse struct {
-	Users []UserWithAccountGroups `json:"users"`
+type UserGroupsQueryResponse struct {
+	Users []UserWithGroups `json:"users"`
 }
 
 // UserAccountGroupsApiResponse is the REST response from PUT /api/users/{id}
@@ -153,16 +156,6 @@ type ContentGroupsQueryResponse struct {
 	ContentGroups []*ContentGroup `json:"businessGroups"`
 }
 
-type UserWithContentGroups struct {
-	Id            int `json:"id"`
-	ContentGroups []struct {
-		Id int `json:"id"`
-	} `json:"contentGroups"`
-}
-
-type UserContentGroupsQueryResponse struct {
-	Users []UserWithContentGroups `json:"users"`
-}
 
 // UserContentGroupsApiResponse is the REST response from PUT /api/users/{id}
 // when updating content groups.

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -141,6 +141,36 @@ type UserAccountGroupsApiResponse struct {
 	AccountGroups []AccountGroup `json:"account-groups"`
 }
 
+// ContentGroup represents a Coupa content group (also called business_group in the API).
+// Content groups restrict user access to specific objects in Coupa.
+// https://compass.coupa.com/en-us/products/product-documentation/integration-technical-documentation/the-coupa-core-api/resources/reference-data-resources/content-groups-api-(business_groups)
+type ContentGroup struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type ContentGroupsQueryResponse struct {
+	ContentGroups []*ContentGroup `json:"businessGroups"`
+}
+
+type UserWithContentGroups struct {
+	Id            int `json:"id"`
+	ContentGroups []struct {
+		Id int `json:"id"`
+	} `json:"contentGroups"`
+}
+
+type UserContentGroupsQueryResponse struct {
+	Users []UserWithContentGroups `json:"users"`
+}
+
+// UserContentGroupsApiResponse is the REST response from PUT /api/users/{id}
+// when updating content groups.
+type UserContentGroupsApiResponse struct {
+	Id            int            `json:"id"`
+	ContentGroups []ContentGroup `json:"content-groups"`
+}
+
 type UpdateUserRequest struct {
 	Active bool `json:"active"`
 }

--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -18,6 +18,10 @@ const (
 	// setAccountGroupPath sets account groups for a user by id.
 	setAccountGroupPath = `/api/users/%d?fields=["id",{"account_groups":["id","name"]}]`
 
+	// setContentGroupPath sets content groups (business_groups) for a user by id.
+	// Note: the Coupa API uses "business_groups" as the URL slug but "content_groups" in the fields projection.
+	setContentGroupPath = `/api/users/%d?fields=["id",{"content_groups":["id","name"]}]`
+
 	// updateUserPath set user id in the path.
 	updateUserPath = `/api/users/%d`
 

--- a/pkg/connector/client/query.go
+++ b/pkg/connector/client/query.go
@@ -74,6 +74,19 @@ const (
 		id accountGroups { id }
 	}
 }`
+
+	getContentGroupsQuery = `query getContentGroups {
+	businessGroups(query: "%s") {
+		id
+		name
+	}
+}`
+
+	getUserContentGroupsByIDQuery = `query getUserContentGroups {
+	users(query: "id=%d") {
+		id contentGroups { id }
+	}
+}`
 )
 
 func pagination(pg string) string {
@@ -129,4 +142,12 @@ func AccountGroupsQuery(pg string) string {
 
 func GetUserAccountGroupsByID(userId int) string {
 	return fmt.Sprintf(getUserAccountGroupsByIDQuery, userId)
+}
+
+func ContentGroupsQuery(pg string) string {
+	return fmt.Sprintf(getContentGroupsQuery, pagination(pg))
+}
+
+func GetUserContentGroupsByID(userId int) string {
+	return fmt.Sprintf(getUserContentGroupsByIDQuery, userId)
 }

--- a/pkg/connector/client/query.go
+++ b/pkg/connector/client/query.go
@@ -87,6 +87,12 @@ const (
 		id contentGroups { id }
 	}
 }`
+
+	getUserAccountAndContentGroupsByIDQuery = `query getUserAccountAndContentGroups {
+	users(query: "id=%d") {
+		id accountGroups { id } contentGroups { id }
+	}
+}`
 )
 
 func pagination(pg string) string {
@@ -150,4 +156,8 @@ func ContentGroupsQuery(pg string) string {
 
 func GetUserContentGroupsByID(userId int) string {
 	return fmt.Sprintf(getUserContentGroupsByIDQuery, userId)
+}
+
+func GetUserAccountAndContentGroupsByID(userId int) string {
+	return fmt.Sprintf(getUserAccountAndContentGroupsByIDQuery, userId)
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -16,17 +16,20 @@ type Connector struct {
 	client            *client.Client
 	ctx               context.Context
 	SyncAccountGroups bool
+	SyncContentGroups bool
 }
 
 // ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
-	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(ctx, d.client, d.SyncAccountGroups),
+	syncers := []connectorbuilder.ResourceSyncerV2{
+		newUserBuilder(ctx, d.client, d.SyncAccountGroups, d.SyncContentGroups),
 		newGroupBuilder(ctx, d.client),
 		newRoleBuilder(ctx, d.client),
 		newLicenseBuilder(ctx, d.client),
 		newAccountGroupBuilder(ctx, d.client),
+		newContentGroupBuilder(ctx, d.client),
 	}
+	return syncers
 }
 
 // Asset takes an input AssetRef and attempts to fetch it using the connector's authenticated http client
@@ -65,6 +68,7 @@ func New(
 	clientId string,
 	clientSecret string,
 	syncAccountGroups bool,
+	syncContentGroups bool,
 	baseURL string,
 ) (*Connector, error) {
 	coupaClient, err := client.New(
@@ -79,5 +83,5 @@ func New(
 		return nil, err
 	}
 
-	return &Connector{client: coupaClient, ctx: ctx, SyncAccountGroups: syncAccountGroups}, nil
+	return &Connector{client: coupaClient, ctx: ctx, SyncAccountGroups: syncAccountGroups, SyncContentGroups: syncContentGroups}, nil
 }

--- a/pkg/connector/content_groups.go
+++ b/pkg/connector/content_groups.go
@@ -204,8 +204,8 @@ func (o *contentGroupBuilder) Revoke(ctx context.Context, g *v2.Grant) (annotati
 	return nil, nil
 }
 
-func (o *contentGroupBuilder) getUserContentGroups(ctx context.Context, userId int) (*client.UserWithContentGroups, error) {
-	var target client.UserContentGroupsQueryResponse
+func (o *contentGroupBuilder) getUserContentGroups(ctx context.Context, userId int) (*client.UserWithGroups, error) {
+	var target client.UserGroupsQueryResponse
 	response, _, err := o.client.Query(
 		ctx,
 		client.GetUserContentGroupsByID(userId),

--- a/pkg/connector/content_groups.go
+++ b/pkg/connector/content_groups.go
@@ -1,0 +1,233 @@
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/conductorone/baton-coupa/pkg/connector/client"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+)
+
+const contentGroupEntitlementName = "member"
+
+type contentGroupBuilder struct {
+	client *client.Client
+}
+
+func (o *contentGroupBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
+	return contentGroupResourceType
+}
+
+func contentGroupResource(cg *client.ContentGroup, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
+	return resourceSdk.NewResource(
+		cg.Name,
+		contentGroupResourceType,
+		strconv.Itoa(cg.ID),
+		resourceSdk.WithParentResourceID(parentResourceID),
+		resourceSdk.WithDescription(fmt.Sprintf("%s content group in Coupa", cg.Name)),
+	)
+}
+
+func (o *contentGroupBuilder) List(
+	ctx context.Context,
+	parentResourceID *v2.ResourceId,
+	opts resourceSdk.SyncOpAttrs,
+) (
+	[]*v2.Resource,
+	*resourceSdk.SyncOpResults,
+	error,
+) {
+	outputResources := make([]*v2.Resource, 0)
+	var outputAnnotations annotations.Annotations
+
+	var target client.ContentGroupsQueryResponse
+	response, ratelimitData, err := o.client.Query(
+		ctx,
+		client.ContentGroupsQuery(opts.PageToken.Token),
+		&target,
+	)
+	outputAnnotations.WithRateLimiting(ratelimitData)
+	if err != nil {
+		return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
+	}
+	defer response.Body.Close()
+
+	lastId := ""
+	for _, cg := range target.ContentGroups {
+		resource, err := contentGroupResource(cg, parentResourceID)
+		if err != nil {
+			return nil, nil, err
+		}
+		outputResources = append(outputResources, resource)
+		lastId = strconv.Itoa(cg.ID)
+	}
+
+	return outputResources, &resourceSdk.SyncOpResults{NextPageToken: lastId, Annotations: outputAnnotations}, nil
+}
+
+// Entitlements returns nothing — entitlements are declared statically via StaticEntitlements.
+func (o *contentGroupBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// StaticEntitlements declares the "member" entitlement once for the content_group resource type.
+// The SDK stamps this template onto every content group resource during sync.
+func (o *contentGroupBuilder) StaticEntitlements(_ context.Context, _ resourceSdk.SyncOpAttrs) ([]*v2.Entitlement, *resourceSdk.SyncOpResults, error) {
+	return []*v2.Entitlement{
+		v2.Entitlement_builder{
+			Slug:        contentGroupEntitlementName,
+			DisplayName: "Member",
+			Description: "Member of content group in Coupa",
+			Purpose:     v2.Entitlement_PURPOSE_VALUE_ASSIGNMENT,
+			GrantableTo: []*v2.ResourceType{userResourceType},
+		}.Build(),
+	}, nil, nil
+}
+
+// Grants is a no-op — content group membership grants are generated from the user
+// builder's Grants() method (one call per user) to avoid the O(content_groups × user_pages)
+// cost of scanning all users for each group. This method is also skipped by the
+// SkipEntitlementsAndGrants annotation on contentGroupResourceType.
+func (o *contentGroupBuilder) Grants(_ context.Context, _ *v2.Resource, _ resourceSdk.SyncOpAttrs) ([]*v2.Grant, *resourceSdk.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (o *contentGroupBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) ([]*v2.Grant, annotations.Annotations, error) {
+	contentGroupIdToAdd, err := strconv.Atoi(entitlement.Resource.Id.Resource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	userId, err := strconv.Atoi(principal.Id.Resource)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	user, err := o.getUserContentGroups(ctx, userId)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, cg := range user.ContentGroups {
+		if cg.Id == contentGroupIdToAdd {
+			return nil, annotations.New(&v2.GrantAlreadyExists{}), nil
+		}
+	}
+
+	newIDs := make([]int, 0, len(user.ContentGroups)+1)
+	for _, cg := range user.ContentGroups {
+		newIDs = append(newIDs, cg.Id)
+	}
+	newIDs = append(newIDs, contentGroupIdToAdd)
+
+	response, _, err := o.client.SetContentGroups(ctx, userId, newIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(response.ContentGroups) != len(newIDs) {
+		return nil, nil, errors.New("baton-coupa: content group was not added to user")
+	}
+
+	newGrant := grant.NewGrant(
+		entitlement.Resource,
+		contentGroupEntitlementName,
+		&v2.ResourceId{
+			ResourceType: userResourceType.Id,
+			Resource:     strconv.Itoa(userId),
+		},
+	)
+
+	return []*v2.Grant{newGrant}, nil, nil
+}
+
+// Revoke removes a content group from a user.
+// Revoking, as with account groups, is a two-step process where you first clear all content
+// groups from the user and then put back the desired ones. This is required because the
+// Coupa PUT /api/users/:id endpoint replaces the entire content-groups array.
+func (o *contentGroupBuilder) Revoke(ctx context.Context, g *v2.Grant) (annotations.Annotations, error) {
+	logger := ctxzap.Extract(ctx)
+	if g.Principal.Id.ResourceType != userResourceType.Id {
+		return nil, fmt.Errorf("baton-coupa: principal resource type is not %s", userResourceType.Id)
+	}
+
+	contentGroupIdToRemove, err := strconv.Atoi(g.Entitlement.Resource.Id.Resource)
+	if err != nil {
+		return nil, err
+	}
+
+	userId, err := strconv.Atoi(g.Principal.Id.Resource)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := o.getUserContentGroups(ctx, userId)
+	if err != nil {
+		return nil, err
+	}
+
+	newIDs := make([]int, 0, len(user.ContentGroups))
+	found := false
+	for _, cg := range user.ContentGroups {
+		if cg.Id == contentGroupIdToRemove {
+			found = true
+			continue
+		}
+		newIDs = append(newIDs, cg.Id)
+	}
+	if !found {
+		return annotations.New(&v2.GrantAlreadyRevoked{}), nil
+	}
+
+	_, _, err = o.client.SetContentGroups(ctx, userId, make([]int, 0))
+	if err != nil {
+		return nil, err
+	}
+
+	userResponse, _, err := o.client.SetContentGroups(ctx, userId, newIDs)
+	if err != nil {
+		logger.Error("baton-coupa: error setting content groups", zap.Error(err), zap.Ints("content_groups", newIDs))
+		return nil, err
+	}
+
+	if len(userResponse.ContentGroups) != len(newIDs) {
+		return nil, errors.New("baton-coupa: content group was not removed from user")
+	}
+
+	return nil, nil
+}
+
+func (o *contentGroupBuilder) getUserContentGroups(ctx context.Context, userId int) (*client.UserWithContentGroups, error) {
+	var target client.UserContentGroupsQueryResponse
+	response, _, err := o.client.Query(
+		ctx,
+		client.GetUserContentGroupsByID(userId),
+		&target,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if len(target.Users) == 0 {
+		return nil, fmt.Errorf("baton-coupa: user %d not found", userId)
+	}
+	if len(target.Users) > 1 {
+		return nil, fmt.Errorf("baton-coupa: multiple users found for id %d", userId)
+	}
+
+	return &target.Users[0], nil
+}
+
+func newContentGroupBuilder(_ context.Context, client *client.Client) *contentGroupBuilder {
+	return &contentGroupBuilder{
+		client: client,
+	}
+}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -81,7 +81,6 @@ var accountGroupResourceType = &v2.ResourceType{
 	DisplayName: "Account Group",
 	Annotations: annotations.New(
 		&v2.SkipEntitlementsAndGrants{},
-		&v2.OptInRequired{},
 		capabilityPermissions(
 			"core.accounting.read",
 			"core.user.read",
@@ -95,7 +94,6 @@ var contentGroupResourceType = &v2.ResourceType{
 	DisplayName: "Content Group",
 	Annotations: annotations.New(
 		&v2.SkipEntitlementsAndGrants{},
-		&v2.OptInRequired{},
 		capabilityPermissions(
 			// Content groups use the business_groups API, which is covered by
 			// core.common.read — already present in the base read-only scope set.

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -9,6 +9,10 @@ import (
 // Used by callers to check whether account groups are included in SyncResourceTypeIDs.
 const AccountGroupResourceTypeID = "account_group"
 
+// ContentGroupResourceTypeID is the stable ID for the content_group resource type.
+// Used by callers to check whether content groups are included in SyncResourceTypeIDs.
+const ContentGroupResourceTypeID = "content_group"
+
 func capabilityPermissions(perms ...string) *v2.CapabilityPermissions {
 	cp := &v2.CapabilityPermissions{}
 	for _, p := range perms {
@@ -80,6 +84,22 @@ var accountGroupResourceType = &v2.ResourceType{
 		&v2.OptInRequired{},
 		capabilityPermissions(
 			"core.accounting.read",
+			"core.user.read",
+			"core.user.write",
+		),
+	),
+}
+
+var contentGroupResourceType = &v2.ResourceType{
+	Id:          ContentGroupResourceTypeID,
+	DisplayName: "Content Group",
+	Annotations: annotations.New(
+		&v2.SkipEntitlementsAndGrants{},
+		&v2.OptInRequired{},
+		capabilityPermissions(
+			// Content groups use the business_groups API, which is covered by
+			// core.common.read — already present in the base read-only scope set.
+			"core.common.read",
 			"core.user.read",
 			"core.user.write",
 		),

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -19,6 +19,7 @@ type userBuilder struct {
 	client            *client.Client
 	resourceType      *v2.ResourceType
 	syncContentGroups bool
+	syncAccountGroups bool
 }
 
 func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -139,31 +140,33 @@ func (o *userBuilder) Grants(
 	var outputAnnotations annotations.Annotations
 
 	// Emit account group grants.
-	var agTarget client.UserAccountGroupsQueryResponse
-	agResponse, agRateLimitData, err := o.client.Query(
-		ctx,
-		client.GetUserAccountGroupsByID(userId),
-		&agTarget,
-	)
-	outputAnnotations.WithRateLimiting(agRateLimitData)
-	if err != nil {
-		return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
-	}
-	defer agResponse.Body.Close()
+	if o.syncAccountGroups {
+		var agTarget client.UserAccountGroupsQueryResponse
+		agResponse, agRateLimitData, err := o.client.Query(
+			ctx,
+			client.GetUserAccountGroupsByID(userId),
+			&agTarget,
+		)
+		outputAnnotations.WithRateLimiting(agRateLimitData)
+		if err != nil {
+			return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
+		}
+		defer agResponse.Body.Close()
 
-	if len(agTarget.Users) > 0 {
-		agUser := agTarget.Users[0]
-		for _, ag := range agUser.AccountGroups {
-			outputGrants = append(outputGrants, grant.NewGrant(
-				&v2.Resource{
-					Id: &v2.ResourceId{
-						ResourceType: accountGroupResourceType.Id,
-						Resource:     strconv.Itoa(ag.Id),
+		if len(agTarget.Users) > 0 {
+			agUser := agTarget.Users[0]
+			for _, ag := range agUser.AccountGroups {
+				outputGrants = append(outputGrants, grant.NewGrant(
+					&v2.Resource{
+						Id: &v2.ResourceId{
+							ResourceType: accountGroupResourceType.Id,
+							Resource:     strconv.Itoa(ag.Id),
+						},
 					},
-				},
-				accountGroupEntitlementName,
-				resource.Id,
-			))
+					accountGroupEntitlementName,
+					resource.Id,
+				))
+			}
 		}
 	}
 
@@ -328,5 +331,6 @@ func newUserBuilder(_ context.Context, client *client.Client, syncAccountGroups 
 		client:            client,
 		resourceType:      rt,
 		syncContentGroups: syncContentGroups,
+		syncAccountGroups: syncAccountGroups,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -16,8 +16,9 @@ import (
 )
 
 type userBuilder struct {
-	client       *client.Client
-	resourceType *v2.ResourceType
+	client            *client.Client
+	resourceType      *v2.ResourceType
+	syncContentGroups bool
 }
 
 func (o *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -117,9 +118,9 @@ func (o *userBuilder) Entitlements(
 	return nil, nil, nil
 }
 
-// Grants returns account group membership grants for this user.
-// Account group grants are generated from the user side to avoid the expensive
-// pattern of fetching all users once per account group.
+// Grants returns account group and/or content group membership grants for this user.
+// These grants are generated from the user side to avoid the expensive pattern of
+// fetching all users once per group.
 func (o *userBuilder) Grants(
 	ctx context.Context,
 	resource *v2.Resource,
@@ -134,36 +135,67 @@ func (o *userBuilder) Grants(
 		return nil, nil, fmt.Errorf("baton-coupa: invalid user ID %q: %w", resource.Id.Resource, err)
 	}
 
-	var target client.UserAccountGroupsQueryResponse
-	response, ratelimitData, err := o.client.Query(
+	outputGrants := make([]*v2.Grant, 0)
+	var outputAnnotations annotations.Annotations
+
+	// Emit account group grants.
+	var agTarget client.UserAccountGroupsQueryResponse
+	agResponse, agRateLimitData, err := o.client.Query(
 		ctx,
 		client.GetUserAccountGroupsByID(userId),
-		&target,
+		&agTarget,
 	)
-	var outputAnnotations annotations.Annotations
-	outputAnnotations.WithRateLimiting(ratelimitData)
+	outputAnnotations.WithRateLimiting(agRateLimitData)
 	if err != nil {
 		return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
 	}
-	defer response.Body.Close()
+	defer agResponse.Body.Close()
 
-	if len(target.Users) == 0 {
-		return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, nil
+	if len(agTarget.Users) > 0 {
+		agUser := agTarget.Users[0]
+		for _, ag := range agUser.AccountGroups {
+			outputGrants = append(outputGrants, grant.NewGrant(
+				&v2.Resource{
+					Id: &v2.ResourceId{
+						ResourceType: accountGroupResourceType.Id,
+						Resource:     strconv.Itoa(ag.Id),
+					},
+				},
+				accountGroupEntitlementName,
+				resource.Id,
+			))
+		}
 	}
 
-	user := target.Users[0]
-	outputGrants := make([]*v2.Grant, 0, len(user.AccountGroups))
-	for _, ag := range user.AccountGroups {
-		outputGrants = append(outputGrants, grant.NewGrant(
-			&v2.Resource{
-				Id: &v2.ResourceId{
-					ResourceType: accountGroupResourceType.Id,
-					Resource:     strconv.Itoa(ag.Id),
-				},
-			},
-			accountGroupEntitlementName,
-			resource.Id,
-		))
+	// Emit content group grants when content group sync is enabled.
+	if o.syncContentGroups {
+		var cgTarget client.UserContentGroupsQueryResponse
+		cgResponse, cgRateLimitData, err := o.client.Query(
+			ctx,
+			client.GetUserContentGroupsByID(userId),
+			&cgTarget,
+		)
+		outputAnnotations.WithRateLimiting(cgRateLimitData)
+		if err != nil {
+			return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
+		}
+		defer cgResponse.Body.Close()
+
+		if len(cgTarget.Users) > 0 {
+			cgUser := cgTarget.Users[0]
+			for _, cg := range cgUser.ContentGroups {
+				outputGrants = append(outputGrants, grant.NewGrant(
+					&v2.Resource{
+						Id: &v2.ResourceId{
+							ResourceType: contentGroupResourceType.Id,
+							Resource:     strconv.Itoa(cg.Id),
+						},
+					},
+					contentGroupEntitlementName,
+					resource.Id,
+				))
+			}
+		}
 	}
 
 	return outputGrants, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, nil
@@ -279,9 +311,9 @@ func (o *userBuilder) CreateAccountCapabilityDetails(
 	}, nil, nil
 }
 
-func newUserBuilder(_ context.Context, client *client.Client, syncAccountGroups bool) *userBuilder {
+func newUserBuilder(_ context.Context, client *client.Client, syncAccountGroups bool, syncContentGroups bool) *userBuilder {
 	annos := annotations.Annotations(userResourceType.GetAnnotations())
-	if syncAccountGroups {
+	if syncAccountGroups || syncContentGroups {
 		annos.Append(&v2.SkipEntitlements{})
 	} else {
 		annos.Append(&v2.SkipEntitlementsAndGrants{})
@@ -293,7 +325,8 @@ func newUserBuilder(_ context.Context, client *client.Client, syncAccountGroups 
 		Annotations: annos,
 	}
 	return &userBuilder{
-		client:       client,
-		resourceType: rt,
+		client:            client,
+		resourceType:      rt,
+		syncContentGroups: syncContentGroups,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -139,28 +139,39 @@ func (o *userBuilder) Grants(
 	outputGrants := make([]*v2.Grant, 0)
 	var outputAnnotations annotations.Annotations
 
+	var userGroups client.UserGroupsQueryResponse
+	var query string
+	switch {
+	case o.syncAccountGroups && o.syncContentGroups:
+		query = client.GetUserAccountAndContentGroupsByID(userId)
+	case o.syncAccountGroups:
+		query = client.GetUserAccountGroupsByID(userId)
+	case o.syncContentGroups:
+		query = client.GetUserContentGroupsByID(userId)
+	default:
+		return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, nil
+	}
+	response, rateLimitData, err := o.client.Query(
+		ctx,
+		query,
+		&userGroups,
+	)
+	outputAnnotations.WithRateLimiting(rateLimitData)
+	if err != nil {
+		return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
+	}
+	defer response.Body.Close()
+
 	// Emit account group grants.
 	if o.syncAccountGroups {
-		var agTarget client.UserAccountGroupsQueryResponse
-		agResponse, agRateLimitData, err := o.client.Query(
-			ctx,
-			client.GetUserAccountGroupsByID(userId),
-			&agTarget,
-		)
-		outputAnnotations.WithRateLimiting(agRateLimitData)
-		if err != nil {
-			return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
-		}
-		defer agResponse.Body.Close()
-
-		if len(agTarget.Users) > 0 {
-			agUser := agTarget.Users[0]
-			for _, ag := range agUser.AccountGroups {
+		if len(userGroups.Users) > 0 {
+			user := userGroups.Users[0]
+			for _, accountGroup := range user.AccountGroups {
 				outputGrants = append(outputGrants, grant.NewGrant(
 					&v2.Resource{
 						Id: &v2.ResourceId{
 							ResourceType: accountGroupResourceType.Id,
-							Resource:     strconv.Itoa(ag.Id),
+							Resource:     strconv.Itoa(accountGroup.Id),
 						},
 					},
 					accountGroupEntitlementName,
@@ -172,26 +183,14 @@ func (o *userBuilder) Grants(
 
 	// Emit content group grants when content group sync is enabled.
 	if o.syncContentGroups {
-		var cgTarget client.UserContentGroupsQueryResponse
-		cgResponse, cgRateLimitData, err := o.client.Query(
-			ctx,
-			client.GetUserContentGroupsByID(userId),
-			&cgTarget,
-		)
-		outputAnnotations.WithRateLimiting(cgRateLimitData)
-		if err != nil {
-			return nil, &resourceSdk.SyncOpResults{Annotations: outputAnnotations}, err
-		}
-		defer cgResponse.Body.Close()
-
-		if len(cgTarget.Users) > 0 {
-			cgUser := cgTarget.Users[0]
-			for _, cg := range cgUser.ContentGroups {
+		if len(userGroups.Users) > 0 {
+			user := userGroups.Users[0]
+			for _, contentGroup := range user.ContentGroups {
 				outputGrants = append(outputGrants, grant.NewGrant(
 					&v2.Resource{
 						Id: &v2.ResourceId{
 							ResourceType: contentGroupResourceType.Id,
-							Resource:     strconv.Itoa(cg.Id),
+							Resource:     strconv.Itoa(contentGroup.Id),
 						},
 					},
 					contentGroupEntitlementName,


### PR DESCRIPTION
<html>
<hr>
<p><strong>Summary</strong></p>
<p>Add support for syncing Coupa Content Groups (<code>business_groups</code>) as entitlements in ConductorOne, with full grant/revoke provisioning support. Requested by Deliveroo (Pylon #10547), with DoorDash as an additional customer need.</p>
<ul>
<li>Syncs Coupa content groups from the Content Groups API (<code>/api/business_groups</code>) as a new <code>content_group</code> resource type</li>
<li>Each content group becomes an entitlement that can be granted to or revoked from users</li>
<li>User-to-content-group grants are emitted from the user builder (same pattern as account groups) to avoid O(groups × user pages) fan-out</li>
<li>Grant/Revoke provisioning updates the user's content group assignments via the REST Users API (<code>PUT /api/users/:id</code>) using a full-replace array pattern</li>
<li>No additional OAuth scope required — <code>core.common.read</code> is already in the base scope set</li>
</ul>
<p><strong>Files Changed</strong></p>

File | Description
-- | --
pkg/connector/content_groups.go | Content group builder with List, StaticEntitlements, Grants (no-op), Grant, Revoke
pkg/connector/client/content_groups.go | SetContentGroups REST API client method
pkg/connector/client/models.go | ContentGroup, ContentGroupsQueryResponse, UserWithContentGroups, API response types
pkg/connector/client/query.go | GraphQL queries for businessGroups and contentGroups user field projection
pkg/connector/client/path.go | setContentGroupPath REST path constant
pkg/connector/client/auth.go | ScopeCommonRead constant with note that it's already in base scopes
pkg/connector/resource_types.go | contentGroupResourceType and ContentGroupResourceTypeID
pkg/connector/connector.go | SyncContentGroups field, wired into ResourceSyncers and New
pkg/connector/users.go | Emits content group grants alongside account group grants in Grants()
cmd/baton-coupa/main.go | Reads syncContentGroups via WillSyncResourceType
baton_capabilities.json | content_group capability entry with sync and provision capabilities
README.md | Documented Content Groups in Data Model section


<p><strong>Implementation Notes</strong></p>
<ul>
<li>Content groups in Coupa are called <code>business_groups</code> at the API level but "Content Groups" in the UI. The resource type ID is <code>content_group</code> and display name is "Content Group" to match the user-facing label.</li>
<li>The GraphQL field names (<code>businessGroups</code>, <code>contentGroups</code>) follow the patterns established by the existing connector. These should be verified against the customer's Coupa GraphQL schema before merging.</li>
<li>The full-replace pattern for <code>PUT /api/users/:id</code> (clear then re-set) is inherited directly from the account groups implementation. Grant fetches current assignments, appends the new ID, and PUTs the full array. Revoke fetches, removes the target ID, clears, then re-sets.</li>
<li><code>core.common.read</code> is confirmed as the required scope for <code>/api/business_groups</code> based on Coupa API documentation. No OAuth client reconfiguration is needed for customers already using the connector.</li>
<li>The connector could not be compiled locally due to the Go 1.25.2 toolchain requirement. CI will validate compilation.</li>
</ul>
<p><strong>Test Plan</strong></p>
<ul>
<li>[ ] Verify the connector compiles successfully with Go 1.25.2</li>
<li>[ ] Verify GraphQL field names (<code>businessGroups</code>, <code>contentGroups</code>) match the live Coupa GraphQL schema</li>
<li>[ ] Confirm <code>content-groups</code> is the correct JSON key for the PUT payload (hyphenated, not underscored)</li>
<li>[ ] Test content group syncing against a Coupa sandbox instance</li>
<li>[ ] Verify content groups appear as resources and entitlements in ConductorOne</li>
<li>[ ] Verify user-to-content-group grants are correctly synced</li>
<li>[ ] Test grant provisioning (assign content group to user)</li>
<li>[ ] Test revoke provisioning (remove content group from user)</li>
<li>[ ] Confirm no regression on existing resource types (Users, Groups, Roles, Licenses, Account Groups)</li>
<li>[ ] Verify opt-in behavior — content groups only sync when selected in the C1 connector config</li>
<li>[ ] Test pagination with large numbers of content groups</li>
</ul>
<p>Closes EPD-2307 | Pylon: #10547</p></body></html>