### PR TITLE
[CXP-595] Add missing Coupa license entitlements (Invoicing, Category Planner, Category Strategy)

### DIFF
--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -98,20 +98,23 @@ type UserRolesPutResponse struct {
 }
 
 type UserLicenseResponse struct {
-	Id              int  `json:"id"`
-	RiskAssessUser  bool `json:"risk-assess-user"`
-	AicUser         bool `json:"aic-user"`
-	PurchasingUser  bool `json:"purchasing-user"`
-	ExpenseUser     bool `json:"expense-user"`
-	SourcingUser    bool `json:"sourcing-user"`
-	InventoryUser   bool `json:"inventory-user"`
-	ContractsUser   bool `json:"contracts-user"`
-	AnalyticsUser   bool `json:"analytics-user"`
-	SpendGuardUser  bool `json:"spend-guard-user"`
-	CcwUser         bool `json:"ccw-user"`
-	SupplyChainUser bool `json:"supply-chain-user"`
-	TravelUser      bool `json:"travel-user"`
-	TreasuryUser    bool `json:"treasury-user"`
+	Id                   int  `json:"id"`
+	RiskAssessUser       bool `json:"risk-assess-user"`
+	AicUser              bool `json:"aic-user"`
+	PurchasingUser       bool `json:"purchasing-user"`
+	ExpenseUser          bool `json:"expense-user"`
+	SourcingUser         bool `json:"sourcing-user"`
+	InventoryUser        bool `json:"inventory-user"`
+	ContractsUser        bool `json:"contracts-user"`
+	AnalyticsUser        bool `json:"analytics-user"`
+	SpendGuardUser       bool `json:"spend-guard-user"`
+	CcwUser              bool `json:"ccw-user"`
+	SupplyChainUser      bool `json:"supply-chain-user"`
+	TravelUser           bool `json:"travel-user"`
+	TreasuryUser         bool `json:"treasury-user"`
+	InvoicingUser        bool `json:"invoicing-user"`
+	CategoryPlannerUser  bool `json:"category-planner-user"`
+	CategoryStrategyUser bool `json:"category-strategy-user"`
 }
 
 type AccountGroup struct {
@@ -155,7 +158,6 @@ type ContentGroup struct {
 type ContentGroupsQueryResponse struct {
 	ContentGroups []*ContentGroup `json:"businessGroups"`
 }
-
 
 // UserContentGroupsApiResponse is the REST response from PUT /api/users/{id}
 // when updating content groups.

--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -13,7 +13,8 @@ const (
 	setLicensePath = `/api/users/%d?fields=["id","analyticsUser","aicUser","ccwUser",` +
 		`"contractsUser","expenseUser","inventoryUser","purchasingUser",` +
 		`"riskAssessUser","sourcingUser","spendGuardUser","supplyChainUser",` +
-		`"travelUser","treasuryUser"]`
+		`"travelUser","treasuryUser","invoicingUser",` +
+		`"categoryPlannerUser","categoryStrategyUser"]`
 
 	// setAccountGroupPath sets account groups for a user by id.
 	setAccountGroupPath = `/api/users/%d?fields=["id",{"account_groups":["id","name"]}]`

--- a/pkg/connector/licenses.go
+++ b/pkg/connector/licenses.go
@@ -57,6 +57,16 @@ func (o *licenseBuilder) List(
 			Description: "An Analytics license",
 		},
 		{
+			Name:        "Category Planner",
+			ID:          "category_planner_user",
+			Description: "A Category Planner license",
+		},
+		{
+			Name:        "Category Strategy",
+			ID:          "category_strategy_user",
+			Description: "A Category Strategy license",
+		},
+		{
 			Name:        "Contingent Workforce",
 			ID:          "ccw-user",
 			Description: "A Contingent Workforce license",
@@ -76,6 +86,11 @@ func (o *licenseBuilder) List(
 			Name:        "Inventory",
 			ID:          "inventory-user",
 			Description: "An Inventory license",
+		},
+		{
+			Name:        "Invoicing",
+			ID:          "invoicing_user",
+			Description: "An Invoicing license",
 		},
 		{
 			// This does not revoke


### PR DESCRIPTION
## Summary

The Coupa Users API exposes three license boolean flags that were missing from the connector's static license list, so those licenses never synced as entitlements in C1:

| API field | License |
| -- | -- |
| `invoicing_user` | Invoicing |
| `category_planner_user` | Category Planner |
| `category_strategy_user` | Category Strategy |

See CXP-595 for the originating request and investigation details.

## Changes

- **`pkg/connector/licenses.go`** — add the three licenses to `coupaLicenses`. Underscore IDs match the existing `treasury_user` entry and the [Coupa Users API docs](https://docs.coupa.com/en/developer-documentation/the-coupa-core-api/resources/reference-data-resources/users-api-users). The ID is the operative value: it's interpolated into the CoupaQL grant query (`users(query: "<id>=true")`) and used as the JSON key in the `SetLicense` PUT body.
- **`pkg/connector/client/models.go`** — add the fields to `UserLicenseResponse` (hyphenated JSON tags, matching the existing fields in the struct).
- **`pkg/connector/client/path.go`** — add the three fields to the shared `setLicensePath` `fields` list for consistency.

## Behavior / compatibility

- These are new **instances** of the existing **License** resource type — not a new resource type — so they sync automatically on the next sync; no C1 opt-in toggle required.
- No new OAuth scopes: the license booleans live on the existing Coupa User object, already covered by `core.user.read` (sync) and `core.user.write` (provisioning).

## Testing

- `go build ./cmd/baton-coupa` ✅
- `go vet ./...` ✅
- `make lint` → 0 issues ✅

⚠️ **Needs live-tenant verification before release.** `setLicensePath` is shared by every license grant/revoke; the `fields` param only shapes the (discarded) response, but a tenant with these modules enabled should confirm:
- the three new License entitlements sync and grants populate;
- **regression:** grant + revoke an existing license (e.g. Expense) still succeeds;
- granting a new license to a test user takes effect in Coupa.
